### PR TITLE
Store 'watchedAt' timestamp in DB

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -50,10 +50,10 @@ function respondToChangesInTitleTag(mutationsList, observer) {
                 "data": {
                     "id": videoID,
                     "title": videoTitle,
-                    "url": videoURL
+                    "url": videoURL,
+                    "watchedAt": new Date().toUTCString()
                 }
             })
-
         }
     }
 }


### PR DESCRIPTION
This PR introduces changes to store the "watchedAt" timestamp in IndexedDB. No changes have being made in the front-end for now.

The timestamp is stored in a different data store. Only the start-time is being stored for now. End-time and duration will be added as part of https://github.com/alfarhanzahedi/ytviews/issues/6.